### PR TITLE
fix cross-validation configuration bug

### DIFF
--- a/src/cross_validation.py
+++ b/src/cross_validation.py
@@ -21,6 +21,7 @@ class CrossValidation:
         problem_type="binary_classification",
         multilabel_delimiter=",",
         random_state=42,
+        num_folds=5,
     ):
         self.dataframe = df
         self.target_cols = target_cols
@@ -35,7 +36,7 @@ class CrossValidation:
             self.dataframe = self.dataframe.sample(frac=1).reset_index(drop=True)
 
     def split(self):
-        if self.problem_type == ["binary_classification", "multiclass_classification"]:
+        if self.problem_type in ["binary_classification", "multiclass_classification"]:
             if self.num_targets != 1:
                 raise Exception("Invalid number of targets for this problem type")
             target = self.target_cols[0]


### PR DESCRIPTION
## Summary
- add `num_folds` argument with default 5 to CrossValidation
- correct problem type check for binary/multiclass cases

## Testing
- `python -m py_compile src/cross_validation.py`
- `python - <<'PY'
import pandas as pd
from src.cross_validation import CrossValidation

df = pd.DataFrame({'feature': range(10), 'target': [0,1]*5})
cv = CrossValidation(df=df, target_cols=['target'], shuffle=True, problem_type='binary_classification', num_folds=5)
print(cv.split().head())
print(cv.split().kfold.value_counts().sort_index())
PY`

------
https://chatgpt.com/codex/tasks/task_b_68a6937f7e2c832e95cf580da51a12b4